### PR TITLE
linux Makefile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories(
 )
 
 # zlib
-find_package(zlib REQUIRED)
+find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 
 # libcpuid
@@ -45,11 +45,11 @@ find_package(cpuid REQUIRED)
 include_directories(${CPUID_INCLUDE_DIR})
 
 # png
-find_package(png REQUIRED)
+find_package(PNG REQUIRED)
 include_directories(${PNG_INCLUDE_DIRS})
 
 # jpeg
-find_package(jpeg REQUIRED)
+find_package(JPEG REQUIRED)
 include_directories(${JPEG_INCLUDE_DIR})
 
 # 3DGE

--- a/Makefiles/Makefile.linux
+++ b/Makefiles/Makefile.linux
@@ -12,8 +12,8 @@ LIBDIR=lib_linux
 
 # The compiler and compiler flags
 
-CC=gcc
-CXX=g++
+CC?=gcc
+CXX?=g++
 
 CFLAGS=-O2 -ffast-math -fno-strict-aliasing -Wall -pipe
 
@@ -86,6 +86,7 @@ makedirs:
 	mkdir -p $(OBJDIR)/epi
 	mkdir -p $(OBJDIR)/glbsp
 	mkdir -p $(OBJDIR)/timidity
+	mkdir -p $(OBJDIR)/opllib
 
 .PHONY: all stripped clean halfclean makedirs
 
@@ -190,6 +191,7 @@ EDGE_OBJS= \
 	$(OBJDIR)/edge/m_option.o   \
 	$(OBJDIR)/edge/m_netgame.o  \
 	$(OBJDIR)/edge/m_random.o   \
+	$(OBJDIR)/edge/m_shift.o    \
 	$(OBJDIR)/edge/n_bcast.o    \
 	$(OBJDIR)/edge/n_reliable.o \
 	$(OBJDIR)/edge/n_network.o  \
@@ -241,6 +243,7 @@ EDGE_OBJS= \
 	$(OBJDIR)/edge/s_music.o    \
 	$(OBJDIR)/edge/s_ogg.o      \
 	$(OBJDIR)/edge/s_timid.o    \
+	$(OBJDIR)/edge/s_opl.o      \
 	$(OBJDIR)/edge/sv_chunk.o   \
 	$(OBJDIR)/edge/sv_glob.o    \
 	$(OBJDIR)/edge/sv_level.o   \
@@ -336,7 +339,7 @@ GLBSP_OBJS= \
 	$(OBJDIR)/glbsp/util.o     \
 	$(OBJDIR)/glbsp/wad.o
 
-$(OBJDIR)/glbsp/%.o: glbsp/src/%.c
+$(OBJDIR)/glbsp/%.o: glbsp/src/%.cc
 	$(CC) $(CFLAGS_GLBSP) -o $@ -c $< 
 
 
@@ -356,6 +359,14 @@ $(OBJDIR)/timidity/%.o: timidity/%.cc
 	$(CXX) $(CFLAGS) -o $@ -c $< 
 
  
+# ---------- OPL ---------------------
+
+OPLLIB_OBJS= \
+	$(OBJDIR)/opllib/opl3.o        \
+	$(OBJDIR)/opllib/oplapi.o
+
+$(OBJDIR)/opllib/%.o: opllib/%.cc
+	$(CXX) $(CFLAGS) -o $@ -c $<
 
 # ---------- FINAL LINK STEP -----------
   
@@ -365,7 +376,8 @@ $(PROGRAM) : $(COAL_OBJS) \
 	     $(EDGE_OBJS) \
 	     $(EPI_OBJS) \
 	     $(GLBSP_OBJS) \
-	     $(TIMIDITY_OBJS)
+	     $(TIMIDITY_OBJS) \
+	     $(OPLLIB_OBJS)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 

--- a/SCONS/SConstruct
+++ b/SCONS/SConstruct
@@ -6,7 +6,7 @@ env.ParseConfig('sdl-config --libs')
 env.Append( CPPFLAGS=['-DLINUX'] )
 env.Append( CPPFLAGS=['-Os','-ffast-math','-fno-strict-aliasing','-Wall','-pipe','-DINLINE_G=inline','-DUSE_OGG','-DGLBSP_PLUGIN', '-DDEH_EDGE_PLUGIN'] )
 
-env.Append( LIBS = ['SDL_mixer', 'SDL_image', 'm', 'jpeg', 'png', 'z', 'Xext', 'X11', 'GL' , 'NL', 'GLEW' , 'ogg' , 'vorbis', 'vorbisfile' ] ) 
+env.Append( LIBS = ['SDL_mixer', 'SDL_image', 'm', 'jpeg', 'png', 'z', 'Xext', 'X11', 'GL' , 'GLEW' , 'ogg' , 'vorbis', 'vorbisfile' ] )
 
 env.Program(
 '3DGE',
@@ -91,6 +91,7 @@ env.Program(
 'src/m_option.cc',
 'src/m_netgame.cc',
 'src/m_random.cc',
+'src/m_shift.cc',
 'src/n_bcast.cc',
 'src/n_reliable.cc',
 'src/n_network.cc',
@@ -122,6 +123,7 @@ env.Program(
 'src/r_effects.cc',
 'src/r_main.cc',
 'src/r_occlude.cc',
+'src/r_bumpmap.cc',
 'src/m_logo.cc',
 'src/r_things.cc',
 'src/r_units.cc',
@@ -140,6 +142,7 @@ env.Program(
 'src/s_sound.cc',
 'src/s_music.cc',
 'src/s_ogg.cc',
+'src/s_opl.cc',
 'src/s_timid.cc',
 'src/sv_chunk.cc',
 'src/sv_glob.cc',
@@ -195,6 +198,8 @@ env.Program(
 'epi/utility.cc',
 'epi/epi_linux.cc',
 'epi/filesystem_linux.cc',
+'opllib/opl3.cc',
+'opllib/oplapi.cc',
 'timidity/common.cc',
 'timidity/instrum.cc',
 'timidity/mix.cc',
@@ -203,15 +208,15 @@ env.Program(
 'timidity/resample.cc',
 'timidity/tables.cc',
 'timidity/timidity.cc',
-'glbsp/src/wad.c',
-'glbsp/src/util.c',
-'glbsp/src/system.c',
-'glbsp/src/seg.c',
-'glbsp/src/reject.c',
-'glbsp/src/node.c',
-'glbsp/src/level.c',
-'glbsp/src/glbsp.c',
-'glbsp/src/blockmap.c',
-'glbsp/src/analyze.c'
+'glbsp/src/wad.cc',
+'glbsp/src/util.cc',
+'glbsp/src/system.cc',
+'glbsp/src/seg.cc',
+'glbsp/src/reject.cc',
+'glbsp/src/node.cc',
+'glbsp/src/level.cc',
+'glbsp/src/glbsp.cc',
+'glbsp/src/blockmap.cc',
+'glbsp/src/analyze.cc'
 ]
 )


### PR DESCRIPTION
While I toiled away making this compile on OpenBSD, I started by using the Makefile.linux.  It seemed to have some missing pieces from the latest developments, so here they are. 

I also got it building with scons, and thus fixed the SConstruct file as well.  further changes will be needed to make it work out of the box on OpenBSD, but might as well get it working for linux again!

Finally CMake is unable to find the png, jpeg, and zlib packages without their names in uppercase.  the cmake modules responsible for finding these packages are also named as such (FindPNG, FindJPEG, FindZLIB) are also named as such, so this seems...right.