### PR TITLE
- r_stretchworld (default 1) - when this is turned on, this alters th…

### DIFF
--- a/src/con_link.cc
+++ b/src/con_link.cc
@@ -74,6 +74,8 @@ extern cvar_c r_crosssize, r_crossbright;
 extern cvar_c r_precache_tex, r_precache_sprite, r_precache_model;
 extern cvar_c r_gl2_path;
 
+extern cvar_c r_stretchworld;
+
 extern cvar_c s_volume, s_mixchan, s_quietfactor;
 extern cvar_c s_rate, s_bits, s_stereo;
 extern cvar_c s_musicvol, s_musicdevice;
@@ -166,6 +168,8 @@ cvar_link_t  all_cvars[] =
 	{ "r_dumbcombine",  &r_dumbcombine,   "",   "0"  },
 	{ "r_dumbclamp",    &r_dumbclamp,     "",   "0"  },
 	{ "r_gl2_path",     &r_gl2_path,      "",   "0"  },
+
+	{ "r_stretchworld", &r_stretchworld, "c",   "1"  },
 
 	{ "am_smoothing",   &am_smoothing,   "c",   "1"  },
 	{ "am_gridsize",    &am_gridsize,    "c",   "128" },

--- a/src/r_main.cc
+++ b/src/r_main.cc
@@ -42,6 +42,8 @@ cvar_c r_aspect;
 cvar_c r_nearclip;
 cvar_c r_farclip;
 
+cvar_c r_stretchworld;
+
 typedef enum
 {
 	PFT_LIGHTING   = (1 << 0),
@@ -143,9 +145,29 @@ void RGL_SetupMatrices3D(void)
 	glMatrixMode(GL_MODELVIEW);
 
 	glLoadIdentity();
-	glRotatef(270.0f - ANG_2_FLOAT(viewvertangle), 1.0f, 0.0f, 0.0f);
-	glRotatef(90.0f - ANG_2_FLOAT(viewangle), 0.0f, 0.0f, 1.0f);
-	glTranslatef(-viewx, -viewy, -viewz);
+
+	if (r_stretchworld.d == 1)
+	{
+		// We have to scale the pitch to account for the pixel stretching, because the playsim doesn't know about this and treats it as 1:1.
+		// This code taken from GZDoom.
+		double radPitch = ANG_2_FLOAT(viewvertangle) / 57.2958;
+		double angx = cos(radPitch);
+		double angy = sin(radPitch) * 1.2;
+		double alen = sqrt(angx*angx + angy*angy);
+		float vvang = (float)(asin(angy / alen)) * 57.2958;
+
+		//glScalef(1.0f, 1.0f, 1/1.2f);
+		glRotatef(270.0f - vvang, 1.0f, 0.0f, 0.0f);
+		glRotatef(90.0f - ANG_2_FLOAT(viewangle), 0.0f, 0.0f, 1.0f);
+		glScalef(1.0f, 1.0f, 1.2f);
+		glTranslatef(-viewx, -viewy, -viewz);
+	}
+	else
+	{
+		glRotatef(270.0f - ANG_2_FLOAT(viewvertangle), 1.0f, 0.0f, 0.0f);
+		glRotatef(90.0f - ANG_2_FLOAT(viewangle), 0.0f, 0.0f, 1.0f);
+		glTranslatef(-viewx, -viewy, -viewz);
+	}
 
 	RGL_CaptureCameraMatrix();
 

--- a/src/r_render.cc
+++ b/src/r_render.cc
@@ -82,7 +82,7 @@ static inline float ExFloorLerpedTop(extrafloor_t *exf)
 
 
 cvar_c debug_hom;
-
+extern cvar_c r_stretchworld;
 
 side_t *sidedef;
 line_t *linedef;
@@ -3131,9 +3131,9 @@ static void InitCamera(mobj_t *mo, bool full_height, float expand_w)
 	view_x_slope = tan(fov * M_PI / 360.0);
 
 	if (full_height)
-		view_y_slope = DOOM_YSLOPE_FULL;
+		view_y_slope = DOOM_YSLOPE_FULL * ((r_stretchworld.d == 1) ? 1.2 : 1.0);
 	else
-		view_y_slope = DOOM_YSLOPE;
+		view_y_slope = DOOM_YSLOPE * ((r_stretchworld.d == 1) ? 1.2 : 1.0);
 
 	viewiszoomed = false;
 


### PR DESCRIPTION
…e view projection matrix such that when looking up or down, the spans look more square. This is to correct the floors pixels looking inappropriately stretched.