### PR TITLE
- Added r_fixspritescale which tries to more closely match sprites to…

### DIFF
--- a/src/con_link.cc
+++ b/src/con_link.cc
@@ -75,6 +75,7 @@ extern cvar_c r_precache_tex, r_precache_sprite, r_precache_model;
 extern cvar_c r_gl2_path;
 
 extern cvar_c r_stretchworld;
+extern cvar_c r_fixspritescale;
 
 extern cvar_c s_volume, s_mixchan, s_quietfactor;
 extern cvar_c s_rate, s_bits, s_stereo;
@@ -170,6 +171,7 @@ cvar_link_t  all_cvars[] =
 	{ "r_gl2_path",     &r_gl2_path,      "",   "0"  },
 
 	{ "r_stretchworld", &r_stretchworld, "c",   "1"  },
+	{ "r_fixspritescale", &r_fixspritescale, "c", "1" },
 
 	{ "am_smoothing",   &am_smoothing,   "c",   "1"  },
 	{ "am_gridsize",    &am_gridsize,    "c",   "128" },

--- a/src/r_things.cc
+++ b/src/r_things.cc
@@ -61,8 +61,11 @@
 #define SHADOW_PROTOTYPE 1
 #define DEBUG  0
 
+#define SCALE_FIX ((r_fixspritescale.d == 1) ? 1.1 : 1.0)
+
 cvar_c r_spriteflip;
 cvar_c r_shadows;
+cvar_c r_fixspritescale;
 
 cvar_c r_crosshair;    // shape
 cvar_c r_crosscolor;   // 0 .. 7
@@ -1020,14 +1023,14 @@ void RGL_WalkThing(drawsub_c *dsub, mobj_t *mo)
 		switch (mo->info->yalign)
 		{
 			case SPYA_TopDown:
-				gzt = mo->z + mo->height + top_offset * mo->info->scale;
-				gzb = gzt - sprite_height * mo->info->scale;
+				gzt = mo->z + mo->height + top_offset * mo->info->scale / SCALE_FIX;
+				gzb = gzt - sprite_height * mo->info->scale / SCALE_FIX;
 				break;
 
 			case SPYA_Middle:
 			{
-				float mz = mo->z + mo->height * 0.5 + top_offset * mo->info->scale;
-				float dz = sprite_height * 0.5 * mo->info->scale;
+				float mz = mo->z + mo->height * 0.5 + top_offset * mo->info->scale / SCALE_FIX;
+				float dz = sprite_height * 0.5 * mo->info->scale / SCALE_FIX;
 
 				gzt = mz + dz;
 				gzb = mz - dz;
@@ -1035,8 +1038,8 @@ void RGL_WalkThing(drawsub_c *dsub, mobj_t *mo)
 			}
 
 			case SPYA_BottomUp: default:
-				gzb = mo->z +  top_offset * mo->info->scale;
-				gzt = gzb + sprite_height * mo->info->scale;
+				gzb = mo->z +  top_offset * mo->info->scale / SCALE_FIX;
+				gzt = gzb + sprite_height * mo->info->scale / SCALE_FIX;
 				break;
 		}
 
@@ -1384,7 +1387,7 @@ skip_shadow:
 	float tex_y1 = dthing->bottom - dthing->orig_bottom;
 	float tex_y2 = tex_y1 + (z1t - z1b);
 
-	float yscale = mo->info->scale * MIR_ZScale();
+	float yscale = mo->info->scale * MIR_ZScale() / SCALE_FIX;
 
 	SYS_ASSERT(h > 0);
 	tex_y1 = top * tex_y1 / (h * yscale);


### PR DESCRIPTION
… their original Doom aspect ratio. (Before, they were slightly too tall)

(Please review before merge)