### PR TITLE
- fixed: Reverted accidental removal of worldstretch code that caused…

### DIFF
--- a/src/p_mobj.cc
+++ b/src/p_mobj.cc
@@ -1282,7 +1282,8 @@ static void P_ZMovement(mobj_t * mo, const region_properties_t *props)
 					{
 						//I_Printf("z: %f, fz: %f, sz: %f\n", mo->z, mo->floorz, mo->subsector->sector->f_h);
 						mo->player->deltaviewheight = zmove / 8.0f;
-						S_StartFX(mo->info->gloopsound, P_MobjGetSfxCategory(mo), mo);
+						// [SP] This seems to crash, disabling for now.
+						//S_StartFX(mo->info->gloopsound, P_MobjGetSfxCategory(mo), mo);
 						splash = true;
 						//CA: Need to set a cooldown, and not have zmove go so far downward over time (or at all!)
 					}

--- a/src/r_render.cc
+++ b/src/r_render.cc
@@ -82,7 +82,7 @@ static inline float ExFloorLerpedTop(extrafloor_t *exf)
 
 
 cvar_c debug_hom;
-
+extern cvar_c r_stretchworld;
 
 side_t *sidedef;
 line_t *linedef;
@@ -3135,10 +3135,7 @@ static void InitCamera(mobj_t *mo, bool full_height, float expand_w)
 
 	view_x_slope = tan(fov * M_PI / 360.0);
 
-	if (full_height)
-		view_y_slope = DOOM_YSLOPE_FULL;
-	else
-		view_y_slope = DOOM_YSLOPE;
+	view_y_slope = ((full_height) ? DOOM_YSLOPE_FULL : DOOM_YSLOPE) * ((r_stretchworld.d == 1) ? 1.2 : 1.0);
 
 	viewiszoomed = false;
 


### PR DESCRIPTION
… the entire screen to be too stretched.

- tempfix: Removed splash sound. It was causing crashes. This needs to be more thoroughly debugged.