### PR TITLE
fix init on BSD systems too

### DIFF
--- a/src/system/i_main.cc
+++ b/src/system/i_main.cc
@@ -180,7 +180,7 @@ fflush(stdout);
 	}
 #endif
 
-#ifdef LINUX
+#if defined(LINUX) || defined(BSD)
 	try 
 	{
 		FILE *dcph;


### PR DESCRIPTION
this issue seen recently on https://github.com/3dfxdev/hyper3DGE/issues/54  affects BSD users as well. fix.