### PR TITLE
Support float32 audio devices.

### DIFF
--- a/src/s_blit.cc
+++ b/src/s_blit.cc
@@ -107,6 +107,7 @@ extern int dev_frag_pairs;
 
 extern bool dev_signed;
 extern bool dev_stereo;
+extern bool dev_float;
 
 
 mix_channel_c::mix_channel_c() : state(CHAN_Empty), data(NULL)
@@ -328,6 +329,20 @@ static void BlitToS16(const int *src, s16_t *dest, int length)
 		else if (val < -CLIP_THRESHHOLD) val = -CLIP_THRESHHOLD;
 
 		*dest++ = (s16_t) (val >> (16-SAFE_BITS));
+	}
+}
+
+static void BlitToF32(const int *src, float *dest, int length)
+{
+	const int *s_end = src + length;
+	while (src < s_end)
+	{
+		int val = *src++;
+
+		     if (val >  CLIP_THRESHHOLD) val =  CLIP_THRESHHOLD;
+		else if (val < -CLIP_THRESHHOLD) val = -CLIP_THRESHHOLD;
+
+		*dest++ = ((float) val) / CLIP_THRESHHOLD;
 	}
 }
 
@@ -589,7 +604,13 @@ void S_MixAllChannels(void *stream, int len)
 	MixQueues(pairs);
 
 	// blit to the SDL stream
-	if (dev_bits == 8)
+	if (dev_float)
+	{
+		// currently, this is always AUDIO_F32, but maybe you want to check
+		//  dev_bits someday.
+		BlitToF32(mix_buffer, (float *)stream, samples);
+	}
+	else if (dev_bits == 8)
 	{
 		if (dev_signed)
 			BlitToS8(mix_buffer, (s8_t *)stream, samples);

--- a/src/system/i_sound.cc
+++ b/src/system/i_sound.cc
@@ -55,8 +55,9 @@ int dev_freq;
 int dev_bits;
 int dev_bytes_per_sample;
 int dev_frag_pairs;
-bool dev_signed;  // S8 vs U8, S16 vs U16
+bool dev_signed;  // S8 vs U8, S16 vs U16, or F32
 bool dev_stereo;
+bool dev_float;  // F32 vs everything else.
 
 
 typedef struct
@@ -253,11 +254,13 @@ void I_StartupSound(void)
 
 	switch (mydev.format)
 	{
-		case AUDIO_S16SYS: dev_bits=16; dev_signed=true;  break;
-		case AUDIO_U16SYS: dev_bits=16; dev_signed=false; break;
+		case AUDIO_S16SYS: dev_bits=16; dev_signed=true; dev_float=false; break;
+		case AUDIO_U16SYS: dev_bits=16; dev_signed=false; dev_float=false; break;
 
-		case AUDIO_S8: dev_bits=8; dev_signed=true;  break;
-		case AUDIO_U8: dev_bits=8; dev_signed=false; break;
+		case AUDIO_S8: dev_bits=8; dev_signed=true; dev_float=false; break;
+		case AUDIO_U8: dev_bits=8; dev_signed=false; dev_float=false; break;
+
+		case AUDIO_F32SYS: dev_bits=32; dev_signed=true; dev_float=true; break;
 
 	    default:
 			I_Printf("I_StartupSound: unsupported format: %d\n", mydev.format);


### PR DESCRIPTION
This is the likely path on Windows Vista and later, once you upgrade to
SDL 2.0.6 or later (which will use WASAPI for audio playback, which wants
to deal exclusively in floating point audio).

Fixes audio subsystem failing to init if you move to a modern Windows and
SDL release.